### PR TITLE
Fix compilation

### DIFF
--- a/src/framework/json.hpp
+++ b/src/framework/json.hpp
@@ -44,7 +44,7 @@ namespace JSON {
  * @param name: file name to load.
  * @returns: the loaded json.
  */
-json_t load(std::string name);
+inline json_t load(std::string name);
 
 /**
  * Check if a key exists in a json_t object.
@@ -52,7 +52,7 @@ json_t load(std::string name);
  * @param js: the json_t to search for key.
  * @returns: true if the key exists, false otherwise.
  */
-bool check_key(std::string key, const json_t &js);
+inline bool check_key(std::string key, const json_t &js);
 
 /**
  * Check if all keys exists in a json_t object.
@@ -60,7 +60,7 @@ bool check_key(std::string key, const json_t &js);
  * @param js: the json_t to search for keys.
  * @returns: true if all keys exists, false otherwise.
  */
-bool check_keys(std::vector<std::string> keys, const json_t &js);
+inline bool check_keys(std::vector<std::string> keys, const json_t &js);
 
 /**
  * Load a json_t object value into a variable if the key name exists.

--- a/src/simulators/statevector/qubitvector_avx2.cpp
+++ b/src/simulators/statevector/qubitvector_avx2.cpp
@@ -18,6 +18,7 @@
  * runtime, only machines with AVX2 support will/could run this code */
 
 #include "qubitvector_avx2.hpp"
+#include "qubitvector.hpp"
 
 using namespace QV;
 
@@ -25,12 +26,12 @@ using namespace QV;
 // Constructors & Destructor
 //------------------------------------------------------------------------------
 template <typename data_t>
-QubitVectorAvx2<data_t>::QubitVectorAvx2(size_t num_qubits) :
-  Base::num_qubits_(0),
-  Base::data_(nullptr),
-  Base::checkpoint_(0)
+QubitVectorAvx2<data_t>::QubitVectorAvx2(size_t num_qubits)
   {
-    Base::set_num_qubits(num_qubits);
+      Base::num_qubits_ = 0;
+      Base::data_ = nullptr;
+      Base::checkpoint_ = 0;
+      Base::set_num_qubits(num_qubits);
 }
 
 template <typename data_t>
@@ -69,8 +70,8 @@ uint_t QubitVectorAvx2<data_t>::_calculate_num_threads(){
   return 1;
 }
 
-
-
+template class QV::QubitVectorAvx2<double>;
+template class QV::QubitVectorAvx2<float>;
 
 
 

--- a/src/simulators/statevector/qubitvector_avx2.hpp
+++ b/src/simulators/statevector/qubitvector_avx2.hpp
@@ -30,7 +30,6 @@
 
 #include "qvintrin_avx.hpp"
 
-
 namespace QV {
 
 // Type aliases
@@ -62,7 +61,7 @@ public:
 
   QubitVectorAvx2();
   explicit QubitVectorAvx2(size_t num_qubits);
-  virtual ~QubitVectorAvx2();
+  virtual ~QubitVectorAvx2(){};
   QubitVectorAvx2(const QubitVectorAvx2& obj) = delete;
   QubitVectorAvx2 &operator=(const QubitVectorAvx2& obj) = delete;
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
A possible fix?
Things to consider:
- The key are these statements at the end of the cpp file: `template class QV::QubitVectorAvx2<type>;`
- I've defined an empty destructor.
- I've had to make some functions `inline` in `json.hpp` so that the linker doesn't find multiples symbols for those functions.

### Details and comments


